### PR TITLE
Add instruction to tsc --init in typescript-sandbox example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can view the TypeScript docs [here](https://www.typescriptlang.org/).
 ## Example
 In your terminal, make a directory called `typescript-sandbox` and `npm init -y`. We're going to play around with some of the basics before moving into a full codealong.
 
-Once, you've done this, `touch index.ts` and we can begin having some fun.
+Once you've done this, `cd` into `typescript-sandbox` and run `tsc --init`. This will create a `tsconfig.json` which contains all of our necessary TypeScript configurations. Finally, `touch index.ts` and we can begin having some fun.
 
 Inside your `index.ts`, include the following code.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can view the TypeScript docs [here](https://www.typescriptlang.org/).
 ## Example
 In your terminal, make a directory called `typescript-sandbox` and `npm init -y`. We're going to play around with some of the basics before moving into a full codealong.
 
-Once you've done this, `cd` into `typescript-sandbox` and run `tsc --init`. This will create a `tsconfig.json` which contains all of our necessary TypeScript configurations. Finally, `touch index.ts` and we can begin having some fun.
+Once you've done this, run `tsc --init`. This will create a `tsconfig.json` file which contains all of our necessary TypeScript configurations. Finally, `touch index.ts` and we can begin having some fun.
 
 Inside your `index.ts`, include the following code.
 


### PR DESCRIPTION
This will prevent linter errors in the beginning stages of the codealong. 
<img width="855" alt="Screen Shot 2021-04-18 at 1 12 51 PM" src="https://user-images.githubusercontent.com/65460818/115159824-dd40cb80-a049-11eb-98be-aed5a543c1f2.png">
